### PR TITLE
Fix: ansible-galaxy minus to underscore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - ansible --version
 
   # Link github repo to ansible-galaxy name
-  - ln -s  $PWD ../while-true-do.postfix
+  - ln -s  $PWD ../while_true_do.postfix
 
 # Run the tests
 script:

--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@ Mailing is one of the major communications for servers. Postfix is commonly used
 
 ## Installation
 
-Install from [Ansible Galaxy](https://galaxy.ansible.com/while-true-do/postfix)
+Install from [Ansible Galaxy](https://galaxy.ansible.com/while_true_do/postfix)
 
 ```
-ansible-galaxy install while-true-do.postfix
+ansible-galaxy install while_true_do.postfix
 ```
 
 Install from [Github](https://github.com/while-true-do/ansible-role-postfix)
 
 ```
-git clone https://github.com/while-true-do/ansible-role-postfix.git while-true-do.postfix
+git clone https://github.com/while-true-do/ansible-role-postfix.git while_true_do.postfix
 ```
 
 ## Requirements
@@ -75,7 +75,7 @@ Simple Example:
 ```yaml
 - hosts: servers 
   roles:
-    - { role: while-true-do.postfix }
+    - { role: while_true_do.postfix }
 ```
 
 ## Testing

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 | While True Do Contribution Guidelines
 
 
-This guideline is only a snapshot. Please have a look [here](https://github.com/while-true-do/community/docs/) to check the latest version.
+This guideline is only a snapshot. Please have a look [here](https://github.com/while-true-do/community/blob/master/docs/CONTRIBUTING.md) to check the latest version.
 
 ## Welcome
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,7 @@
 dependencies: []
 
 galaxy_info:
+  role_name: postfix
   author: while-true-do.org
   description: A role to install and configure postfix.
   company: while-true-do.org

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,4 +2,4 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - while-true-do.postfix
+    - while_true_do.postfix

--- a/update-meta-files.sh
+++ b/update-meta-files.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
 # Description:
-#   update-skeleton.sh is a very minimal script to update the skeleton with 
-#   some additional content from while-true-do.org. It will not remove files, 
+#   update-skeleton.sh is a very minimal script to update the skeleton with
+#   some additional content from while-true-do.org. It will not remove files,
 #   you created. Replacement must be acknowledged.
 
 function usage {
@@ -90,7 +90,7 @@ function update_all {
 }
 
 while getopts 'admst' opts; do
-  
+
   case "${opts}" in
     a) update_all ;;
     d) update_docs ;;


### PR DESCRIPTION
# Fix: ansible-galaxy minus to underscore

Ansible Galaxy decided to change "-" to "_" and there
is no way currently to roll this back.
So change the role names and galaxy links to "while_true_do"

## Reference

 - Resolves:
